### PR TITLE
Historical and merged metadata flows

### DIFF
--- a/es-cli/src/main/kotlin/EventsMain.kt
+++ b/es-cli/src/main/kotlin/EventsMain.kt
@@ -1,8 +1,6 @@
 package io.provenance.eventstream
 
 import io.provenance.eventstream.decoder.moshiDecoderAdapter
-import io.provenance.eventstream.extensions.awaitShutdown
-import io.provenance.eventstream.net.defaultOkHttpClient
 import io.provenance.eventstream.net.okHttpNetAdapter
 import io.provenance.eventstream.stream.historicalBlockMetaData
 import io.provenance.eventstream.stream.mapHistoricalHeaderData
@@ -17,9 +15,8 @@ import mu.KotlinLogging
 
 fun main() = runBlocking {
     val log = KotlinLogging.logger {}
-    val host = "localhost:26657"
-    val okHttp = defaultOkHttpClient()
-    val netAdapter = okHttpNetAdapter(host, okHttp)
+    val host = "rpc.test.provenance.io:443"
+    val netAdapter = okHttpNetAdapter(host, tls = true)
     val decoderAdapter = moshiDecoderAdapter()
 
     // Example is not collected.
@@ -35,8 +32,8 @@ fun main() = runBlocking {
     // Use metadataFlow to fetch from:(current - 10000) to:(current + 5).
     // This will combine the historical flow and live flow to create an ordered stream of BlockHeaders.
     val current = netAdapter.rpcAdapter.getCurrentHeight()!!
-    metadataFlow(netAdapter, decoderAdapter, from = current - 10000, to = current + 5)
+    metadataFlow(netAdapter, decoderAdapter, from = current - 1000, to = current)
         .collect { println("recv:${it.height}") }
 
-    okHttp.awaitShutdown()
+    netAdapter.shutdown()
 }

--- a/es-cli/src/main/kotlin/EventsMain.kt
+++ b/es-cli/src/main/kotlin/EventsMain.kt
@@ -1,23 +1,137 @@
 package io.provenance.eventstream
 
+import io.provenance.eventstream.decoder.DecoderAdapter
 import io.provenance.eventstream.decoder.moshiDecoderAdapter
 import io.provenance.eventstream.extensions.awaitShutdown
+import io.provenance.eventstream.net.NetAdapter
 import io.provenance.eventstream.net.defaultOkHttpClient
 import io.provenance.eventstream.net.okHttpNetAdapter
+import io.provenance.eventstream.stream.historicalBlockMetaData
+import io.provenance.eventstream.stream.mapHistoricalHeaderData
+import io.provenance.eventstream.stream.mapLiveHeaderData
+import io.provenance.eventstream.stream.models.BlockHeader
 import io.provenance.eventstream.stream.nodeEventStream
 import io.provenance.eventstream.stream.rpc.response.MessageType
-import io.provenance.eventstream.stream.toLiveMetaDataStream
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.buffer
+import kotlinx.coroutines.flow.channelFlow
 import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.dropWhile
+import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.selects.select
+import mu.KotlinLogging
+import java.util.concurrent.atomic.AtomicLong
 
 fun main() = runBlocking {
+    val log = KotlinLogging.logger {}
+    val host = "rpc.test.provenance.io:443"
     val okHttp = defaultOkHttpClient()
-    val netAdapter = okHttpNetAdapter("ws://localhost:26657", okHttp)
+    val netAdapter = okHttpNetAdapter(host, okHttp, tls = true)
     val decoderAdapter = moshiDecoderAdapter()
 
-    nodeEventStream<MessageType.NewBlock>(netAdapter, decoderAdapter)
-        .toLiveMetaDataStream()
-        .collect { println("newBlock:\n$it") }
+    // historicalBlockMetaData(netAdapter, 1, 100)
+    //     .mapHistoricalHeaderData()
+    //     .onEach { if (it.height % 1500 == 0L) { log.info { "oldBlock: ${it.height}" } } }
+
+    // nodeEventStream<MessageType.NewBlockHeader>(netAdapter, decoderAdapter)
+    //     .mapLiveHeaderData()
+    //     .onEach { println("liveBlock: ${it.height}") }
+
+    val current = netAdapter.rpcAdapter.getCurrentHeight()!!
+    metadataFlow(netAdapter, decoderAdapter, from = current - 10000, to = current + 5)
+        .collect { println("recv:${it.height}") }
 
     okHttp.awaitShutdown()
+}
+
+/**
+ *
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+fun metadataFlow(netAdapter: NetAdapter, decoderAdapter: DecoderAdapter, from: Long? = null, to: Long? = null): Flow<BlockHeader> = channelFlow {
+    val parent = this
+    val log = KotlinLogging.logger {}
+    val channel = Channel<BlockHeader>(capacity = 10_000) // buffer for: 10_000 * 6s block time / 60s/m / 60m/h == 16 2/3 hrs buffer time.
+    val liveJob = launch {
+        nodeEventStream<MessageType.NewBlockHeader>(netAdapter, decoderAdapter)
+            .mapLiveHeaderData()
+            .buffer()
+            .collect { channel.send(it) }
+    }
+    val current = netAdapter.rpcAdapter.getCurrentHeight()!!
+    log.debug { "hist//live split point:$current" }
+
+    // Determine if we need live data.
+    // ie: if to is null, or more than current,
+    val needLive = to == null || to > current
+
+    // Determine if we need historical data.
+    // ie: if from is null, or less than current, then we do.
+    val needHist = from == null || from < current
+    log.debug { "from:$from to:$to current:$current needHist:$needHist needLive:$needLive" }
+
+    // Cancel live job and channel if unneeded.
+    if (!needLive) {
+        liveJob.cancel()
+        channel.close()
+    }
+
+    // Process historical stream if needed.
+    val lastSeen = AtomicLong(0)
+    if (needHist) {
+        historicalBlockMetaData(netAdapter, from ?: 1, current)
+            .mapHistoricalHeaderData()
+            .collect {
+                send(it)
+                lastSeen.set(it.height)
+            }
+    }
+
+    // Live flow. Skip any dupe blocks.
+    if (needLive) {
+        var firstLive = channel.receive()
+        var lastCurrent = current
+
+        // Determine if we have a gap between the last seen current and first received that needs to be filled.
+        // If fetching and emitting the gap takes longer that the time to fetch a new block, loop and do it again
+        // until the next block to be emitted is the head of the channel.
+        do {
+            log.debug { "gap fill from ${lastCurrent + 1} to ${firstLive.height}" }
+            historicalBlockMetaData(netAdapter, lastCurrent + 1, firstLive.height)
+                .mapHistoricalHeaderData()
+                .collect { block ->
+                    // Update the lastSeen height after successful send.
+                    select {
+                        onSend(block) {
+                            lastSeen.set(block.height)
+                        }
+                    }
+                }
+            lastCurrent = firstLive.height
+            firstLive = channel.receive()
+
+        } while (lastCurrent+1 < firstLive.height)
+
+        // Send the last known head of the channel.
+        send(firstLive)
+        lastSeen.set(firstLive.height)
+
+        // Continue receiving everything else live.
+        // Drop anything between current head and the last fetched history record.
+        channel.receiveAsFlow().dropWhile {
+            it.height <= lastSeen.get()
+        }.collect { block ->
+            select {
+                onSend(block) {
+                    if (to != null && block.height >= to) {
+                        parent.close()
+                    }
+                }
+            }
+        }
+    }
 }

--- a/es-cli/src/main/kotlin/EventsMain.kt
+++ b/es-cli/src/main/kotlin/EventsMain.kt
@@ -2,12 +2,9 @@ package io.provenance.eventstream
 
 import io.provenance.eventstream.decoder.moshiDecoderAdapter
 import io.provenance.eventstream.net.okHttpNetAdapter
-import io.provenance.eventstream.stream.historicalBlockMetaData
-import io.provenance.eventstream.stream.mapHistoricalHeaderData
-import io.provenance.eventstream.stream.mapLiveHeaderData
-import io.provenance.eventstream.stream.metadataFlow
-import io.provenance.eventstream.stream.nodeEventStream
-import io.provenance.eventstream.stream.rpc.response.MessageType.NewBlockHeader
+import io.provenance.eventstream.stream.flows.historicalMetadataFlow
+import io.provenance.eventstream.stream.flows.liveMetadataFlow
+import io.provenance.eventstream.stream.flows.metadataFlow
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.runBlocking
@@ -20,13 +17,11 @@ fun main() = runBlocking {
     val decoderAdapter = moshiDecoderAdapter()
 
     // Example is not collected.
-    historicalBlockMetaData(netAdapter, 1, 100)
-        .mapHistoricalHeaderData()
+    historicalMetadataFlow(netAdapter, 1, 100)
         .onEach { if (it.height % 1500 == 0L) { log.info { "oldBlock: ${it.height}" } } }
 
     // Example is not collected.
-    nodeEventStream<NewBlockHeader>(netAdapter, decoderAdapter)
-        .mapLiveHeaderData()
+    liveMetadataFlow(netAdapter, decoderAdapter)
         .onEach { println("liveBlock: ${it.height}") }
 
     // Use metadataFlow to fetch from:(current - 10000) to:(current + 5).

--- a/es-cli/src/main/kotlin/EventsMain.kt
+++ b/es-cli/src/main/kotlin/EventsMain.kt
@@ -17,9 +17,9 @@ import mu.KotlinLogging
 
 fun main() = runBlocking {
     val log = KotlinLogging.logger {}
-    val host = "rpc.test.provenance.io:443"
+    val host = "localhost:26657"
     val okHttp = defaultOkHttpClient()
-    val netAdapter = okHttpNetAdapter(host, okHttp, tls = true)
+    val netAdapter = okHttpNetAdapter(host, okHttp)
     val decoderAdapter = moshiDecoderAdapter()
 
     // Example is not collected.

--- a/es-cli/src/main/kotlin/EventsMain.kt
+++ b/es-cli/src/main/kotlin/EventsMain.kt
@@ -1,30 +1,19 @@
 package io.provenance.eventstream
 
-import io.provenance.eventstream.decoder.DecoderAdapter
 import io.provenance.eventstream.decoder.moshiDecoderAdapter
 import io.provenance.eventstream.extensions.awaitShutdown
-import io.provenance.eventstream.net.NetAdapter
 import io.provenance.eventstream.net.defaultOkHttpClient
 import io.provenance.eventstream.net.okHttpNetAdapter
 import io.provenance.eventstream.stream.historicalBlockMetaData
 import io.provenance.eventstream.stream.mapHistoricalHeaderData
 import io.provenance.eventstream.stream.mapLiveHeaderData
-import io.provenance.eventstream.stream.models.BlockHeader
+import io.provenance.eventstream.stream.metadataFlow
 import io.provenance.eventstream.stream.nodeEventStream
-import io.provenance.eventstream.stream.rpc.response.MessageType
-import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.channels.Channel
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.buffer
-import kotlinx.coroutines.flow.channelFlow
+import io.provenance.eventstream.stream.rpc.response.MessageType.NewBlockHeader
 import kotlinx.coroutines.flow.collect
-import kotlinx.coroutines.flow.dropWhile
-import kotlinx.coroutines.flow.receiveAsFlow
-import kotlinx.coroutines.launch
+import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.selects.select
 import mu.KotlinLogging
-import java.util.concurrent.atomic.AtomicLong
 
 fun main() = runBlocking {
     val log = KotlinLogging.logger {}
@@ -33,105 +22,21 @@ fun main() = runBlocking {
     val netAdapter = okHttpNetAdapter(host, okHttp, tls = true)
     val decoderAdapter = moshiDecoderAdapter()
 
-    // historicalBlockMetaData(netAdapter, 1, 100)
-    //     .mapHistoricalHeaderData()
-    //     .onEach { if (it.height % 1500 == 0L) { log.info { "oldBlock: ${it.height}" } } }
+    // Example is not collected.
+    historicalBlockMetaData(netAdapter, 1, 100)
+        .mapHistoricalHeaderData()
+        .onEach { if (it.height % 1500 == 0L) { log.info { "oldBlock: ${it.height}" } } }
 
-    // nodeEventStream<MessageType.NewBlockHeader>(netAdapter, decoderAdapter)
-    //     .mapLiveHeaderData()
-    //     .onEach { println("liveBlock: ${it.height}") }
+    // Example is not collected.
+    nodeEventStream<NewBlockHeader>(netAdapter, decoderAdapter)
+        .mapLiveHeaderData()
+        .onEach { println("liveBlock: ${it.height}") }
 
+    // Use metadataFlow to fetch from:(current - 10000) to:(current + 5).
+    // This will combine the historical flow and live flow to create an ordered stream of BlockHeaders.
     val current = netAdapter.rpcAdapter.getCurrentHeight()!!
     metadataFlow(netAdapter, decoderAdapter, from = current - 10000, to = current + 5)
         .collect { println("recv:${it.height}") }
 
     okHttp.awaitShutdown()
-}
-
-/**
- *
- */
-@OptIn(ExperimentalCoroutinesApi::class)
-fun metadataFlow(netAdapter: NetAdapter, decoderAdapter: DecoderAdapter, from: Long? = null, to: Long? = null): Flow<BlockHeader> = channelFlow {
-    val parent = this
-    val log = KotlinLogging.logger {}
-    val channel = Channel<BlockHeader>(capacity = 10_000) // buffer for: 10_000 * 6s block time / 60s/m / 60m/h == 16 2/3 hrs buffer time.
-    val liveJob = launch {
-        nodeEventStream<MessageType.NewBlockHeader>(netAdapter, decoderAdapter)
-            .mapLiveHeaderData()
-            .buffer()
-            .collect { channel.send(it) }
-    }
-    val current = netAdapter.rpcAdapter.getCurrentHeight()!!
-    log.debug { "hist//live split point:$current" }
-
-    // Determine if we need live data.
-    // ie: if to is null, or more than current,
-    val needLive = to == null || to > current
-
-    // Determine if we need historical data.
-    // ie: if from is null, or less than current, then we do.
-    val needHist = from == null || from < current
-    log.debug { "from:$from to:$to current:$current needHist:$needHist needLive:$needLive" }
-
-    // Cancel live job and channel if unneeded.
-    if (!needLive) {
-        liveJob.cancel()
-        channel.close()
-    }
-
-    // Process historical stream if needed.
-    val lastSeen = AtomicLong(0)
-    if (needHist) {
-        historicalBlockMetaData(netAdapter, from ?: 1, current)
-            .mapHistoricalHeaderData()
-            .collect {
-                send(it)
-                lastSeen.set(it.height)
-            }
-    }
-
-    // Live flow. Skip any dupe blocks.
-    if (needLive) {
-        var firstLive = channel.receive()
-        var lastCurrent = current
-
-        // Determine if we have a gap between the last seen current and first received that needs to be filled.
-        // If fetching and emitting the gap takes longer that the time to fetch a new block, loop and do it again
-        // until the next block to be emitted is the head of the channel.
-        do {
-            log.debug { "gap fill from ${lastCurrent + 1} to ${firstLive.height}" }
-            historicalBlockMetaData(netAdapter, lastCurrent + 1, firstLive.height)
-                .mapHistoricalHeaderData()
-                .collect { block ->
-                    // Update the lastSeen height after successful send.
-                    select {
-                        onSend(block) {
-                            lastSeen.set(block.height)
-                        }
-                    }
-                }
-            lastCurrent = firstLive.height
-            firstLive = channel.receive()
-
-        } while (lastCurrent+1 < firstLive.height)
-
-        // Send the last known head of the channel.
-        send(firstLive)
-        lastSeen.set(firstLive.height)
-
-        // Continue receiving everything else live.
-        // Drop anything between current head and the last fetched history record.
-        channel.receiveAsFlow().dropWhile {
-            it.height <= lastSeen.get()
-        }.collect { block ->
-            select {
-                onSend(block) {
-                    if (to != null && block.height >= to) {
-                        parent.close()
-                    }
-                }
-            }
-        }
-    }
 }

--- a/es-core/src/main/kotlin/io/provenance/eventstream/Defaults.kt
+++ b/es-core/src/main/kotlin/io/provenance/eventstream/Defaults.kt
@@ -16,6 +16,7 @@ import io.provenance.eventstream.adapter.json.decoder.MoshiDecoderEngine
 import io.provenance.eventstream.config.Config
 import io.provenance.eventstream.config.Environment
 import io.provenance.eventstream.decoder.defaultMoshi
+import io.provenance.eventstream.net.NetAdapter
 import io.provenance.eventstream.net.defaultOkHttpClient
 import io.provenance.eventstream.net.okHttpNetAdapter
 import io.provenance.eventstream.stream.BlockStreamOptions
@@ -138,9 +139,9 @@ fun defaultTendermintFetcher(rpcUri: String): TendermintBlockFetcher =
  * Create a default websocket builder for the event stream.
  */
 @OptIn(ExperimentalTime::class)
-fun defaultEventStreamBuilder(wsFactory: () -> WebSocket): Scarlet.Builder {
+fun defaultEventStreamBuilder(netAdapter: NetAdapter): Scarlet.Builder {
     val factory = object : WebSocket.Factory {
-        override fun create(): WebSocket = wsFactory()
+        override fun create(): WebSocket = netAdapter.wsAdapter.invoke()
     }
     return Scarlet.Builder()
         .webSocketFactory(factory)

--- a/es-core/src/main/kotlin/io/provenance/eventstream/Defaults.kt
+++ b/es-core/src/main/kotlin/io/provenance/eventstream/Defaults.kt
@@ -20,12 +20,12 @@ import io.provenance.eventstream.net.NetAdapter
 import io.provenance.eventstream.net.defaultOkHttpClient
 import io.provenance.eventstream.net.okHttpNetAdapter
 import io.provenance.eventstream.stream.BlockStreamOptions
-import io.provenance.eventstream.stream.DEFAULT_THROTTLE_PERIOD
 import io.provenance.eventstream.stream.DefaultBlockStreamFactory
 import io.provenance.eventstream.stream.TendermintServiceClient
 import io.provenance.eventstream.stream.WebSocketChannel
 import io.provenance.eventstream.stream.clients.TendermintBlockFetcher
 import io.provenance.eventstream.stream.clients.TendermintServiceOpenApiClient
+import io.provenance.eventstream.stream.flows.DEFAULT_THROTTLE_PERIOD
 import io.provenance.eventstream.stream.models.StreamBlockImpl
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import okhttp3.OkHttpClient

--- a/es-core/src/main/kotlin/io/provenance/eventstream/decoder/DecoderAdapter.kt
+++ b/es-core/src/main/kotlin/io/provenance/eventstream/decoder/DecoderAdapter.kt
@@ -1,4 +1,4 @@
-package io.provenance.eventstream.stream.decoder
+package io.provenance.eventstream.decoder
 
 import io.provenance.eventstream.WsDecoderAdapter
 import io.provenance.eventstream.adapter.json.decoder.DecoderEngine

--- a/es-core/src/main/kotlin/io/provenance/eventstream/decoder/MoshiAdapter.kt
+++ b/es-core/src/main/kotlin/io/provenance/eventstream/decoder/MoshiAdapter.kt
@@ -5,8 +5,6 @@ import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import com.tinder.scarlet.messageadapter.moshi.MoshiMessageAdapter
 import io.provenance.eventstream.adapter.json.JSONObjectAdapter
 import io.provenance.eventstream.adapter.json.decoder.MoshiDecoderEngine
-import io.provenance.eventstream.stream.decoder.DecoderAdapter
-import io.provenance.eventstream.stream.decoder.decoderAdapter
 
 /**
  * Create the default [Moshi] JSON serializer/deserializer.

--- a/es-core/src/main/kotlin/io/provenance/eventstream/flow/Extensions.kt
+++ b/es-core/src/main/kotlin/io/provenance/eventstream/flow/Extensions.kt
@@ -171,8 +171,8 @@ fun <T> Flow<T>.windowed(size: Int, step: Int, partialWindows: Boolean, timeout:
  *
  * Both [size] and [step] must be positive and can be greater than the number of elements in this collection.
  * @param size the number of elements to take in each window
- * @param step the number of elements to move the window forward by on an each step.
- * @param partialWindows controls whether or not to keep partial windows in the end if any.
+ * @param step the number of elements to move the window forward by each step.
+ * @param partialWindows controls whether to keep partial windows in the end if any.
  * @param timeout If an element is not emitted in the specified duration, the buffer will be emitted downstream if
  *  it is non-empty.
  * @param pollInterval Delay interval between each check of the buffer for elements.

--- a/es-core/src/main/kotlin/io/provenance/eventstream/net/NetAdapter.kt
+++ b/es-core/src/main/kotlin/io/provenance/eventstream/net/NetAdapter.kt
@@ -1,0 +1,9 @@
+package io.provenance.eventstream.net
+
+import io.provenance.eventstream.WsAdapter
+import io.provenance.eventstream.stream.clients.BlockFetcher
+
+interface NetAdapter {
+    val wsAdapter: WsAdapter
+    val rpcAdapter: BlockFetcher
+}

--- a/es-core/src/main/kotlin/io/provenance/eventstream/net/NetAdapter.kt
+++ b/es-core/src/main/kotlin/io/provenance/eventstream/net/NetAdapter.kt
@@ -10,10 +10,12 @@ import io.provenance.eventstream.stream.clients.BlockFetcher
  * @param rpcAdapter The [BlockFetcher] used to make rpc calls to the node.
  * @return The [NetAdapter] instance.
  */
-fun netAdapter(wsAdapter: WsAdapter, rpcAdapter: BlockFetcher): NetAdapter {
+fun netAdapter(wsAdapter: WsAdapter, rpcAdapter: BlockFetcher, shutdown: () -> Unit): NetAdapter {
     return object : NetAdapter {
         override val wsAdapter: WsAdapter = wsAdapter
         override val rpcAdapter: BlockFetcher = rpcAdapter
+
+        override fun shutdown() = shutdown()
     }
 }
 
@@ -23,4 +25,6 @@ fun netAdapter(wsAdapter: WsAdapter, rpcAdapter: BlockFetcher): NetAdapter {
 interface NetAdapter {
     val wsAdapter: WsAdapter
     val rpcAdapter: BlockFetcher
+
+    fun shutdown()
 }

--- a/es-core/src/main/kotlin/io/provenance/eventstream/net/NetAdapter.kt
+++ b/es-core/src/main/kotlin/io/provenance/eventstream/net/NetAdapter.kt
@@ -3,6 +3,23 @@ package io.provenance.eventstream.net
 import io.provenance.eventstream.WsAdapter
 import io.provenance.eventstream.stream.clients.BlockFetcher
 
+/**
+ * Create a generic [NetAdapter] to interface with the web socket channels.
+ *
+ * @param wsAdapter The [WsAdapter] used to interface with [com.tinder.scarlet.Scarlet]
+ * @param rpcAdapter The [BlockFetcher] used to make rpc calls to the node.
+ * @return The [NetAdapter] instance.
+ */
+fun netAdapter(wsAdapter: WsAdapter, rpcAdapter: BlockFetcher): NetAdapter {
+    return object : NetAdapter {
+        override val wsAdapter: WsAdapter = wsAdapter
+        override val rpcAdapter: BlockFetcher = rpcAdapter
+    }
+}
+
+/**
+ * Provide a common interface for an http framework to interface with the websocket and block fetcher functions.
+ */
 interface NetAdapter {
     val wsAdapter: WsAdapter
     val rpcAdapter: BlockFetcher

--- a/es-core/src/main/kotlin/io/provenance/eventstream/net/OkHttpAdapter.kt
+++ b/es-core/src/main/kotlin/io/provenance/eventstream/net/OkHttpAdapter.kt
@@ -1,6 +1,7 @@
 package io.provenance.eventstream.net
 
 import com.tinder.scarlet.websocket.okhttp.newWebSocketFactory
+import io.provenance.eventstream.extensions.awaitShutdown
 import io.provenance.eventstream.stream.clients.TendermintBlockFetcher
 import io.provenance.eventstream.stream.clients.TendermintServiceOpenApiClient
 import mu.KotlinLogging
@@ -41,6 +42,7 @@ fun okHttpNetAdapter(host: String, okHttpClient: OkHttpClient = defaultOkHttpCli
 
     return netAdapter(
         okHttpClient.newWebSocketFactory("${wsUri.scheme}://${wsUri.host}:${wsUri.port}/websocket")::create,
-        TendermintBlockFetcher(TendermintServiceOpenApiClient(rpcUri.toASCIIString()))
+        TendermintBlockFetcher(TendermintServiceOpenApiClient(rpcUri.toASCIIString())),
+        okHttpClient::awaitShutdown
     )
 }

--- a/es-core/src/main/kotlin/io/provenance/eventstream/net/OkHttpAdapter.kt
+++ b/es-core/src/main/kotlin/io/provenance/eventstream/net/OkHttpAdapter.kt
@@ -1,8 +1,6 @@
 package io.provenance.eventstream.net
 
 import com.tinder.scarlet.websocket.okhttp.newWebSocketFactory
-import io.provenance.eventstream.WsAdapter
-import io.provenance.eventstream.stream.clients.BlockFetcher
 import io.provenance.eventstream.stream.clients.TendermintBlockFetcher
 import io.provenance.eventstream.stream.clients.TendermintServiceOpenApiClient
 import mu.KotlinLogging
@@ -14,7 +12,7 @@ import kotlin.time.Duration.Companion.seconds
 import kotlin.time.ExperimentalTime
 
 /**
- * Create a default okHttpClient to use for the event stream.
+ * Create a default [OkHttpClient] to use within the event stream.
  */
 @OptIn(ExperimentalTime::class)
 fun defaultOkHttpClient(pingInterval: Duration = 10.seconds, readInterval: Duration = 60.seconds) =
@@ -23,23 +21,26 @@ fun defaultOkHttpClient(pingInterval: Duration = 10.seconds, readInterval: Durat
         .readTimeout(readInterval.inWholeMilliseconds, TimeUnit.MILLISECONDS)
         .build()
 
+/**
+ * Create the [OkHttpClient] flavor of the required [NetAdapter] fields.
+ *
+ * @param hosh The node host address to connect to.
+ * @param okHttpClient The [OkHttpClient] instance to use for http calls.
+ * @param tls Are the connections running over tls?
+ * @return The [NetAdapter] instance.
+ */
 fun okHttpNetAdapter(host: String, okHttpClient: OkHttpClient = defaultOkHttpClient(), tls: Boolean = false): NetAdapter {
     fun scheme(pre: String) = if (tls) "${pre}s" else pre
 
-    return object : NetAdapter {
-        private val log = KotlinLogging.logger {}
+    val log = KotlinLogging.logger {}
+    val wsUri = URI.create("${scheme("ws")}://$host")
+    val rpcUri = URI.create("${scheme("http")}://$host")
 
-        val wsUri = URI.create("${scheme("ws")}://$host")
-        val rpcUri = URI.create("${scheme("http")}://$host")
+    log.info { "initializing ws endpoint:$wsUri" }
+    log.info { "initializing rpc endpoint:$rpcUri" }
 
-        init {
-            log.info { "initializing ws endpoint:$wsUri" }
-            log.info { "initializing rpc endpoint:$rpcUri" }
-        }
-
-        override val wsAdapter: WsAdapter =
-            okHttpClient.newWebSocketFactory("${wsUri.scheme}://${wsUri.host}:${wsUri.port}/websocket")::create
-        override val rpcAdapter: BlockFetcher =
-            TendermintBlockFetcher(TendermintServiceOpenApiClient(rpcUri.toASCIIString()))
-    }
+    return netAdapter(
+        okHttpClient.newWebSocketFactory("${wsUri.scheme}://${wsUri.host}:${wsUri.port}/websocket")::create,
+        TendermintBlockFetcher(TendermintServiceOpenApiClient(rpcUri.toASCIIString()))
+    )
 }

--- a/es-core/src/main/kotlin/io/provenance/eventstream/stream/EventStream.kt
+++ b/es-core/src/main/kotlin/io/provenance/eventstream/stream/EventStream.kt
@@ -5,9 +5,12 @@ import io.provenance.blockchain.stream.api.BlockSource
 import io.provenance.eventstream.adapter.json.decoder.DecoderEngine
 import io.provenance.eventstream.coroutines.DefaultDispatcherProvider
 import io.provenance.eventstream.coroutines.DispatcherProvider
+import io.provenance.eventstream.decoder.DecoderAdapter
+import io.provenance.eventstream.net.NetAdapter
 import io.provenance.eventstream.stream.clients.BlockData
 import io.provenance.eventstream.stream.clients.TendermintBlockFetcher
 import io.provenance.eventstream.stream.models.Block
+import io.provenance.eventstream.stream.models.BlockHeader
 import io.provenance.eventstream.stream.models.BlockMeta
 import io.provenance.eventstream.stream.models.EncodedBlockchainEvent
 import io.provenance.eventstream.stream.models.StreamBlock
@@ -17,6 +20,7 @@ import io.provenance.eventstream.stream.models.extensions.blockEvents
 import io.provenance.eventstream.stream.models.extensions.dateTime
 import io.provenance.eventstream.stream.models.extensions.txData
 import io.provenance.eventstream.stream.models.extensions.txEvents
+import io.provenance.eventstream.stream.rpc.response.MessageType
 import io.provenance.eventstream.utils.backoff
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -32,6 +36,7 @@ import kotlinx.coroutines.flow.buffer
 import kotlinx.coroutines.flow.cancellable
 import kotlinx.coroutines.flow.channelFlow
 import kotlinx.coroutines.flow.consumeAsFlow
+import kotlinx.coroutines.flow.dropWhile
 import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.flatMapConcat
@@ -44,7 +49,10 @@ import kotlinx.coroutines.flow.merge
 import kotlinx.coroutines.flow.onCompletion
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.onStart
+import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.retryWhen
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.selects.select
 import kotlin.time.ExperimentalTime
 import mu.KotlinLogging
 import java.io.EOFException
@@ -52,6 +60,103 @@ import java.net.ConnectException
 import java.net.SocketException
 import java.net.SocketTimeoutException
 import java.util.concurrent.CompletionException
+import java.util.concurrent.atomic.AtomicLong
+
+/**
+ * Create a [Flow] of [BlockHeader] from height to height.
+ *
+ * This flow will intelligently determine how to merge the live and history flows to
+ * create a seamless stream of [BlockHeader] objects.
+ *
+ * @param netAdapter The [NetAdapter] to use for network interfacing.
+ * @param decoderAdapter The [DecoderAdapter] to use to marshal json.
+ * @param from The `from` height, if omitted, height 1 is used.
+ * @param to The `to` height, if omitted, no end is assumed.
+ * @return The [Flow] of [BlockHeader].
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+fun metadataFlow(netAdapter: NetAdapter, decoderAdapter: DecoderAdapter, from: Long? = null, to: Long? = null): Flow<BlockHeader> = channelFlow {
+    val parent = this
+    val log = KotlinLogging.logger {}
+    val channel = Channel<BlockHeader>(capacity = 10_000) // buffer for: 10_000 * 6s block time / 60s/m / 60m/h == 16 2/3 hrs buffer time.
+    val liveJob = launch {
+        nodeEventStream<MessageType.NewBlockHeader>(netAdapter, decoderAdapter)
+            .mapLiveHeaderData()
+            .buffer()
+            .collect { channel.send(it) }
+    }
+    val current = netAdapter.rpcAdapter.getCurrentHeight()!!
+    log.debug { "hist//live split point:$current" }
+
+    // Determine if we need live data.
+    // ie: if to is null, or more than current,
+    val needLive = to == null || to > current
+
+    // Determine if we need historical data.
+    // ie: if from is null, or less than current, then we do.
+    val needHist = from == null || from < current
+    log.debug { "from:$from to:$to current:$current needHist:$needHist needLive:$needLive" }
+
+    // Cancel live job and channel if unneeded.
+    if (!needLive) {
+        liveJob.cancel()
+        channel.close()
+    }
+
+    // Process historical stream if needed.
+    val lastSeen = AtomicLong(0)
+    if (needHist) {
+        historicalBlockMetaData(netAdapter, from ?: 1, current)
+            .mapHistoricalHeaderData()
+            .collect {
+                send(it)
+                lastSeen.set(it.height)
+            }
+    }
+
+    // Live flow. Skip any dupe blocks.
+    if (needLive) {
+        var firstLive = channel.receive()
+        var lastCurrent = current
+
+        // Determine if we have a gap between the last seen current and first received that needs to be filled.
+        // If fetching and emitting the gap takes longer that the time to fetch a new block, loop and do it again
+        // until the next block to be emitted is the head of the channel.
+        do {
+            log.debug { "gap fill from ${lastCurrent + 1} to ${firstLive.height}" }
+            historicalBlockMetaData(netAdapter, lastCurrent + 1, firstLive.height)
+                .mapHistoricalHeaderData()
+                .collect { block ->
+                    // Update the lastSeen height after successful send.
+                    select {
+                        onSend(block) {
+                            lastSeen.set(block.height)
+                        }
+                    }
+                }
+            lastCurrent = firstLive.height
+            firstLive = channel.receive()
+        } while (lastCurrent + 1 < firstLive.height)
+
+        // Send the last known head of the channel.
+        send(firstLive)
+        lastSeen.set(firstLive.height)
+
+        // Continue receiving everything else live.
+        // Drop anything between current head and the last fetched history record.
+        channel.receiveAsFlow().dropWhile {
+            it.height <= lastSeen.get()
+        }.collect { block ->
+            select {
+                onSend(block) {
+                    if (to != null && block.height >= to) {
+                        parent.close()
+                    }
+                }
+            }
+        }
+    }
+}
 
 @OptIn(FlowPreview::class, ExperimentalTime::class)
 @ExperimentalCoroutinesApi
@@ -205,6 +310,7 @@ class EventStream(
         val txErrors = blockResult.txErroredEvents(blockDatetime) { index: Int -> block.txData(index) }
         return StreamBlockImpl(block, blockEvents, blockTxResults, txEvents, txErrors)
     }
+
     /**
      * Constructs a Flow of live and historical blocks, plus associated event data.
      *

--- a/es-core/src/main/kotlin/io/provenance/eventstream/stream/EventStream.kt
+++ b/es-core/src/main/kotlin/io/provenance/eventstream/stream/EventStream.kt
@@ -5,22 +5,18 @@ import io.provenance.blockchain.stream.api.BlockSource
 import io.provenance.eventstream.adapter.json.decoder.DecoderEngine
 import io.provenance.eventstream.coroutines.DefaultDispatcherProvider
 import io.provenance.eventstream.coroutines.DispatcherProvider
-import io.provenance.eventstream.decoder.DecoderAdapter
-import io.provenance.eventstream.net.NetAdapter
 import io.provenance.eventstream.stream.clients.BlockData
 import io.provenance.eventstream.stream.clients.TendermintBlockFetcher
 import io.provenance.eventstream.stream.models.Block
-import io.provenance.eventstream.stream.models.BlockHeader
 import io.provenance.eventstream.stream.models.BlockMeta
 import io.provenance.eventstream.stream.models.EncodedBlockchainEvent
 import io.provenance.eventstream.stream.models.StreamBlock
 import io.provenance.eventstream.stream.models.StreamBlockImpl
-import io.provenance.eventstream.stream.models.extensions.txErroredEvents
 import io.provenance.eventstream.stream.models.extensions.blockEvents
 import io.provenance.eventstream.stream.models.extensions.dateTime
 import io.provenance.eventstream.stream.models.extensions.txData
+import io.provenance.eventstream.stream.models.extensions.txErroredEvents
 import io.provenance.eventstream.stream.models.extensions.txEvents
-import io.provenance.eventstream.stream.rpc.response.MessageType
 import io.provenance.eventstream.utils.backoff
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -31,12 +27,11 @@ import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.asFlow
-import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.buffer
 import kotlinx.coroutines.flow.cancellable
 import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.consumeAsFlow
-import kotlinx.coroutines.flow.dropWhile
 import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.flatMapConcat
@@ -49,114 +44,14 @@ import kotlinx.coroutines.flow.merge
 import kotlinx.coroutines.flow.onCompletion
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.onStart
-import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.retryWhen
-import kotlinx.coroutines.launch
-import kotlinx.coroutines.selects.select
-import kotlin.time.ExperimentalTime
 import mu.KotlinLogging
 import java.io.EOFException
 import java.net.ConnectException
 import java.net.SocketException
 import java.net.SocketTimeoutException
 import java.util.concurrent.CompletionException
-import java.util.concurrent.atomic.AtomicLong
-
-/**
- * Create a [Flow] of [BlockHeader] from height to height.
- *
- * This flow will intelligently determine how to merge the live and history flows to
- * create a seamless stream of [BlockHeader] objects.
- *
- * @param netAdapter The [NetAdapter] to use for network interfacing.
- * @param decoderAdapter The [DecoderAdapter] to use to marshal json.
- * @param from The `from` height, if omitted, height 1 is used.
- * @param to The `to` height, if omitted, no end is assumed.
- * @return The [Flow] of [BlockHeader].
- */
-@OptIn(ExperimentalCoroutinesApi::class)
-fun metadataFlow(netAdapter: NetAdapter, decoderAdapter: DecoderAdapter, from: Long? = null, to: Long? = null): Flow<BlockHeader> = channelFlow {
-    val parent = this
-    val log = KotlinLogging.logger {}
-    val channel = Channel<BlockHeader>(capacity = 10_000) // buffer for: 10_000 * 6s block time / 60s/m / 60m/h == 16 2/3 hrs buffer time.
-    val liveJob = launch {
-        nodeEventStream<MessageType.NewBlockHeader>(netAdapter, decoderAdapter)
-            .mapLiveHeaderData()
-            .buffer()
-            .collect { channel.send(it) }
-    }
-    val current = netAdapter.rpcAdapter.getCurrentHeight()!!
-    log.debug { "hist//live split point:$current" }
-
-    // Determine if we need live data.
-    // ie: if to is null, or more than current,
-    val needLive = to == null || to > current
-
-    // Determine if we need historical data.
-    // ie: if from is null, or less than current, then we do.
-    val needHist = from == null || from < current
-    log.debug { "from:$from to:$to current:$current needHist:$needHist needLive:$needLive" }
-
-    // Cancel live job and channel if unneeded.
-    if (!needLive) {
-        liveJob.cancel()
-        channel.close()
-    }
-
-    // Process historical stream if needed.
-    val lastSeen = AtomicLong(0)
-    if (needHist) {
-        historicalBlockMetaData(netAdapter, from ?: 1, current)
-            .mapHistoricalHeaderData()
-            .collect {
-                send(it)
-                lastSeen.set(it.height)
-            }
-    }
-
-    // Live flow. Skip any dupe blocks.
-    if (needLive) {
-        var firstLive = channel.receive()
-        var lastCurrent = current
-
-        // Determine if we have a gap between the last seen current and first received that needs to be filled.
-        // If fetching and emitting the gap takes longer that the time to fetch a new block, loop and do it again
-        // until the next block to be emitted is the head of the channel.
-        do {
-            log.debug { "gap fill from ${lastCurrent + 1} to ${firstLive.height}" }
-            historicalBlockMetaData(netAdapter, lastCurrent + 1, firstLive.height)
-                .mapHistoricalHeaderData()
-                .collect { block ->
-                    // Update the lastSeen height after successful send.
-                    select {
-                        onSend(block) {
-                            lastSeen.set(block.height)
-                        }
-                    }
-                }
-            lastCurrent = firstLive.height
-            firstLive = channel.receive()
-        } while (lastCurrent + 1 < firstLive.height)
-
-        // Send the last known head of the channel.
-        send(firstLive)
-        lastSeen.set(firstLive.height)
-
-        // Continue receiving everything else live.
-        // Drop anything between current head and the last fetched history record.
-        channel.receiveAsFlow().dropWhile {
-            it.height <= lastSeen.get()
-        }.collect { block ->
-            select {
-                onSend(block) {
-                    if (to != null && block.height >= to) {
-                        parent.close()
-                    }
-                }
-            }
-        }
-    }
-}
+import kotlin.time.ExperimentalTime
 
 @OptIn(FlowPreview::class, ExperimentalTime::class)
 @ExperimentalCoroutinesApi

--- a/es-core/src/main/kotlin/io/provenance/eventstream/stream/EventStreamService.kt
+++ b/es-core/src/main/kotlin/io/provenance/eventstream/stream/EventStreamService.kt
@@ -59,7 +59,7 @@ fun webSocketLifecycle(lifecycle: LifecycleRegistry): WebSocketLifecycle = objec
      * Note: this must be called prior to any receiving any events on the RPC stream.
      */
     override fun start() {
-        log.info { "start()" }
+        log.debug { "start()" }
         lifecycle.onNext(Lifecycle.State.Started)
     }
 
@@ -67,7 +67,7 @@ fun webSocketLifecycle(lifecycle: LifecycleRegistry): WebSocketLifecycle = objec
      * Stops the provided event stream from receiving events.
      */
     override fun stop() {
-        log.info { "stop()" }
+        log.debug { "stop()" }
         lifecycle.onNext(Lifecycle.State.Stopped.AndAborted)
     }
 }

--- a/es-core/src/main/kotlin/io/provenance/eventstream/stream/LiveMetaDataStream.kt
+++ b/es-core/src/main/kotlin/io/provenance/eventstream/stream/LiveMetaDataStream.kt
@@ -14,6 +14,11 @@ import kotlinx.coroutines.flow.map
 import mu.KotlinLogging
 
 /**
+ *
+ */
+fun Flow<MessageType.NewBlockHeader>.mapLiveHeaderData() = map { it.header.data.value!!.header!! }
+
+/**
  * Convert a [Flow] of type [MessageType.NewBlock] into a [Flow] of [Block].
  *
  * Mimic the behavior of the [LiveMetaDataStream] using [nodeEventStream] as a source.

--- a/es-core/src/main/kotlin/io/provenance/eventstream/stream/LiveMetaDataStream.kt
+++ b/es-core/src/main/kotlin/io/provenance/eventstream/stream/LiveMetaDataStream.kt
@@ -4,6 +4,7 @@ import com.tinder.scarlet.Message
 import com.tinder.scarlet.WebSocket
 import io.provenance.eventstream.adapter.json.decoder.DecoderEngine
 import io.provenance.eventstream.stream.models.Block
+import io.provenance.eventstream.stream.models.BlockHeader
 import io.provenance.eventstream.stream.rpc.request.Subscribe
 import io.provenance.eventstream.stream.rpc.response.MessageType
 import kotlinx.coroutines.CancellationException
@@ -14,9 +15,9 @@ import kotlinx.coroutines.flow.map
 import mu.KotlinLogging
 
 /**
- *
+ * Convert a [Flow] of type [MessageType.NewBlockHeader] into a flow of [BlockHeader]
  */
-fun Flow<MessageType.NewBlockHeader>.mapLiveHeaderData() = map { it.header.data.value!!.header!! }
+fun Flow<MessageType.NewBlockHeader>.mapLiveHeaderData(): Flow<BlockHeader> = map { it.header.data.value!!.header!! }
 
 /**
  * Convert a [Flow] of type [MessageType.NewBlock] into a [Flow] of [Block].

--- a/es-core/src/main/kotlin/io/provenance/eventstream/stream/LiveMetaDataStream.kt
+++ b/es-core/src/main/kotlin/io/provenance/eventstream/stream/LiveMetaDataStream.kt
@@ -4,28 +4,13 @@ import com.tinder.scarlet.Message
 import com.tinder.scarlet.WebSocket
 import io.provenance.eventstream.adapter.json.decoder.DecoderEngine
 import io.provenance.eventstream.stream.models.Block
-import io.provenance.eventstream.stream.models.BlockHeader
 import io.provenance.eventstream.stream.rpc.request.Subscribe
 import io.provenance.eventstream.stream.rpc.response.MessageType
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.channelFlow
-import kotlinx.coroutines.flow.map
 import mu.KotlinLogging
-
-/**
- * Convert a [Flow] of type [MessageType.NewBlockHeader] into a flow of [BlockHeader]
- */
-fun Flow<MessageType.NewBlockHeader>.mapLiveHeaderData(): Flow<BlockHeader> = map { it.header.data.value!!.header!! }
-
-/**
- * Convert a [Flow] of type [MessageType.NewBlock] into a [Flow] of [Block].
- *
- * Mimic the behavior of the [LiveMetaDataStream] using [nodeEventStream] as a source.
- */
-fun Flow<MessageType.NewBlock>.toLiveMetaDataStream(): Flow<Block> =
-    map { it.block.data.value.block }
 
 /**
  * Create a [Flow] of [Block] from a [WebSocketService].

--- a/es-core/src/main/kotlin/io/provenance/eventstream/stream/MetadataStream.kt
+++ b/es-core/src/main/kotlin/io/provenance/eventstream/stream/MetadataStream.kt
@@ -1,21 +1,80 @@
 package io.provenance.eventstream.stream
 
 import io.provenance.eventstream.config.Options
+import io.provenance.eventstream.net.NetAdapter
+import io.provenance.eventstream.stream.EventStream.Companion.TENDERMINT_MAX_QUERY_RANGE
 import io.provenance.eventstream.stream.clients.TendermintBlockFetcher
 import io.provenance.eventstream.stream.models.BlockMeta
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.flow.DEFAULT_CONCURRENCY
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.asFlow
+import kotlinx.coroutines.flow.channelFlow
 import kotlinx.coroutines.flow.emitAll
-import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flatMapConcat
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.withContext
 import mu.KotlinLogging
+import kotlin.coroutines.CoroutineContext
 import kotlin.math.floor
 import kotlin.math.max
 import kotlin.math.min
 
+/**
+ *
+ */
+fun Flow<BlockMeta>.mapHistoricalHeaderData() = map { it.header!! }
+
+/**
+ *
+ */
+fun historicalBlockMetaData(netAdapter: NetAdapter, from: Long = 1, to: Long? = null): Flow<BlockMeta> = flow {
+    suspend fun currentHeight() =
+        netAdapter.rpcAdapter.getCurrentHeight() ?: throw RuntimeException("cannot fetch current height")
+
+    val realTo = to ?: currentHeight()
+    require(from <= realTo) { "from:$from must be less than to:$realTo" }
+
+    emitAll((from .. realTo).toList().toMetaData(netAdapter))
+}
+
+/**
+ *
+ */
+@OptIn(FlowPreview::class, ExperimentalCoroutinesApi::class)
+fun List<Long>.toMetaData(
+    netAdapter: NetAdapter,
+    concurrency: Int = DEFAULT_CONCURRENCY,
+    context: CoroutineContext = Dispatchers.Default
+): Flow<BlockMeta> {
+    val fetcher = netAdapter.rpcAdapter
+    val log = KotlinLogging.logger {}
+    return channelFlow {
+        chunked(TENDERMINT_MAX_QUERY_RANGE).map { LongRange(it.first(), it.last()) }
+            .chunked(concurrency).map { chunks ->
+                withContext(context) {
+                    log.debug { "processing chunks:$chunks" }
+                    chunks.toList().map {
+                        async {
+                            fetcher.getBlocksMeta(it.first, it.last)
+                                ?.sortedBy { it.header?.height }
+                                ?: throw RuntimeException("failed to fetch for range:[${it.first} .. ${it.last}]")
+                        }
+                    }.awaitAll().flatten()
+                }.forEach { send(it) }
+            }
+    }
+}
+
+/**
+ *
+ */
 class MetadataStream(
     val options: BlockStreamOptions,
     val fetcher: TendermintBlockFetcher

--- a/es-core/src/main/kotlin/io/provenance/eventstream/stream/flows/HistoricalMetadataFlow.kt
+++ b/es-core/src/main/kotlin/io/provenance/eventstream/stream/flows/HistoricalMetadataFlow.kt
@@ -1,0 +1,103 @@
+package io.provenance.eventstream.stream.flows
+
+import io.provenance.eventstream.net.NetAdapter
+import io.provenance.eventstream.stream.EventStream
+import io.provenance.eventstream.stream.models.BlockHeader
+import io.provenance.eventstream.stream.models.BlockMeta
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.flow.DEFAULT_CONCURRENCY
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.emitAll
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.withContext
+import mu.KotlinLogging
+import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.EmptyCoroutineContext
+
+/**
+ * Convert a [Flow] of [BlockMeta] into a [Flow] of [BlockHeader].
+ */
+fun Flow<BlockMeta>.mapHistoricalHeaderData(): Flow<BlockHeader> = map { it.header!! }
+
+/**
+ * Create a [Flow] of historical [BlockHeader] from a node.
+ *
+ * @param netAdapter The [NetAdapter] to use to interface with the node rpc.
+ * @param from The `from` height to begin the stream with.
+ * @param to The `to` height to fetch until. If omitted, use the current height.
+ * @param concurrency The coroutine concurrency setting for async parallel fetches.
+ * @param context The coroutine context to execute the async parallel fetches.
+ * @return The [Flow] of [BlockHeader]
+ */
+fun historicalMetadataFlow(
+    netAdapter: NetAdapter,
+    from: Long = 1,
+    to: Long? = null,
+    concurrency: Int = DEFAULT_CONCURRENCY,
+    context: CoroutineContext = EmptyCoroutineContext
+): Flow<BlockHeader> =
+    historicalBlockMetaFlow(netAdapter, from, to, concurrency, context).mapHistoricalHeaderData()
+
+/**
+ * Create a [Flow] of historical [BlockMeta] from a node.
+ *
+ * @param netAdapter The [NetAdapter] to use to interface with the node rpc.
+ * @param from The `from` height to begin the stream with.
+ * @param to The `to` height to fetch until. If omitted, use the current height.
+ * @param concurrency The coroutine concurrency setting for async parallel fetches.
+ * @param context The coroutine context to execute the async parallel fetches.
+ * @return The [Flow] of [BlockMeta]
+ */
+internal fun historicalBlockMetaFlow(
+    netAdapter: NetAdapter,
+    from: Long = 1,
+    to: Long? = null,
+    concurrency: Int = DEFAULT_CONCURRENCY,
+    context: CoroutineContext = EmptyCoroutineContext
+): Flow<BlockMeta> = flow {
+    suspend fun currentHeight() =
+        netAdapter.rpcAdapter.getCurrentHeight() ?: throw RuntimeException("cannot fetch current height")
+
+    val realTo = to ?: currentHeight()
+    require(from <= realTo) { "from:$from must be less than to:$realTo" }
+
+    emitAll((from..realTo).toList().toMetaData(netAdapter, concurrency, context))
+}
+
+/**
+ * Convert a list of heights into a [Flow] of [BlockMeta].
+ *
+ * @param netAdapter The [NetAdapter] to use to interface with the node rpc.
+ * @param concurrency The coroutine concurrency setting for async parallel fetches.
+ * @param context The coroutine context to execute the async parallel fetches.
+ * @return The [Flow] of [BlockMeta]
+ */
+@OptIn(FlowPreview::class, ExperimentalCoroutinesApi::class)
+fun List<Long>.toMetaData(
+    netAdapter: NetAdapter,
+    concurrency: Int = DEFAULT_CONCURRENCY,
+    context: CoroutineContext = EmptyCoroutineContext
+): Flow<BlockMeta> {
+    val fetcher = netAdapter.rpcAdapter
+    val log = KotlinLogging.logger {}
+    return channelFlow {
+        chunked(EventStream.TENDERMINT_MAX_QUERY_RANGE).map { LongRange(it.first(), it.last()) }
+            .chunked(concurrency).map { chunks ->
+                withContext(context) {
+                    log.debug { "processing chunks:$chunks" }
+                    chunks.toList().map {
+                        async {
+                            fetcher.getBlocksMeta(it.first, it.last)
+                                ?.sortedBy { it.header?.height }
+                                ?: throw RuntimeException("failed to fetch for range:[${it.first} .. ${it.last}]")
+                        }
+                    }.awaitAll().flatten()
+                }.forEach { send(it) }
+            }
+    }
+}

--- a/es-core/src/main/kotlin/io/provenance/eventstream/stream/flows/LiveMetadataFlow.kt
+++ b/es-core/src/main/kotlin/io/provenance/eventstream/stream/flows/LiveMetadataFlow.kt
@@ -1,0 +1,84 @@
+package io.provenance.eventstream.stream.flows
+
+import com.tinder.scarlet.lifecycle.LifecycleRegistry
+import io.provenance.eventstream.decoder.DecoderAdapter
+import io.provenance.eventstream.defaultLifecycle
+import io.provenance.eventstream.defaultWebSocketChannel
+import io.provenance.eventstream.net.NetAdapter
+import io.provenance.eventstream.stream.LiveMetaDataStream
+import io.provenance.eventstream.stream.WebSocketChannel
+import io.provenance.eventstream.stream.WebSocketService
+import io.provenance.eventstream.stream.models.Block
+import io.provenance.eventstream.stream.models.BlockHeader
+import io.provenance.eventstream.stream.models.BlockMeta
+import io.provenance.eventstream.stream.rpc.request.Subscribe
+import io.provenance.eventstream.stream.rpc.response.MessageType
+import io.provenance.eventstream.stream.withLifecycle
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import kotlin.time.Duration
+
+/**
+ * Convert a [Flow] of type [MessageType.NewBlockHeader] into a flow of [BlockHeader]
+ */
+fun Flow<MessageType.NewBlockHeader>.mapLiveHeaderData(): Flow<BlockHeader> = map { it.header.data.value!!.header!! }
+
+/**
+ * Convert a [Flow] of type [MessageType.NewBlock] into a [Flow] of [Block].
+ *
+ * Mimic the behavior of the [LiveMetaDataStream] using [nodeEventStream] as a source.
+ */
+fun Flow<MessageType.NewBlock>.mapLiveBlockData(): Flow<Block> =
+    map { it.block.data.value.block }
+
+/**
+ * Create a [Flow] of historical [BlockMeta] from a node.
+ *
+ * Convenience wrapper around [nodeEventStream] and [mapLiveHeaderData]
+ *
+ * @param netAdapter The [NetAdapter] to use to connect to the node.
+ * @param decoderAdapter The [DecoderAdapter] to use to convert from json.
+ * @param throttle The web socket throttle duration.
+ * @param lifecycle The [LifecycleRegistry] instance used to manage startup and shutdown.
+ * @param channel The [WebSocketChannel] used to receive incoming websocket events.
+ * @param wss The [WebSocketService] used to manage the channel.
+ */
+fun liveMetadataFlow(
+    netAdapter: NetAdapter,
+    decoderAdapter: DecoderAdapter,
+    throttle: Duration = DEFAULT_THROTTLE_PERIOD,
+    lifecycle: LifecycleRegistry = defaultLifecycle(throttle),
+    channel: WebSocketChannel = defaultWebSocketChannel(netAdapter.wsAdapter, decoderAdapter.wsDecoder, throttle, lifecycle),
+    wss: WebSocketService = channel.withLifecycle(lifecycle),
+): Flow<BlockHeader> {
+    return nodeEventStream<MessageType.NewBlockHeader>(netAdapter, decoderAdapter, throttle, lifecycle, channel, wss)
+        .mapLiveHeaderData()
+}
+/**
+ * Create an event stream subscription to a node.
+ *
+ * @param netAdapter The [NetAdapter] to use to connect to the node.
+ * @param decoderAdapter The [DecoderAdapter] to use to convert from json.
+ * @param throttle The web socket throttle duration.
+ * @param lifecycle The [LifecycleRegistry] instance used to manage startup and shutdown.
+ * @param channel The [WebSocketChannel] used to receive incoming websocket events.
+ * @param wss The [WebSocketService] used to manage the channel.
+ */
+inline fun <reified T : MessageType> nodeEventStream(
+    netAdapter: NetAdapter,
+    decoderAdapter: DecoderAdapter,
+    throttle: Duration = DEFAULT_THROTTLE_PERIOD,
+    lifecycle: LifecycleRegistry = defaultLifecycle(throttle),
+    channel: WebSocketChannel = defaultWebSocketChannel(netAdapter.wsAdapter, decoderAdapter.wsDecoder, throttle, lifecycle),
+    wss: WebSocketService = channel.withLifecycle(lifecycle),
+): Flow<T> {
+    // Only supported NewBlock and NewBlockHeader right now.
+    require(T::class == MessageType.NewBlock::class || T::class == MessageType.NewBlockHeader::class) {
+        "unsupported MessageType.${T::class.simpleName}"
+    }
+
+    val subscription = T::class.simpleName
+    val sub = Subscribe("tm.event='$subscription'")
+    return webSocketClient(sub, netAdapter, decoderAdapter, throttle, lifecycle, channel, wss)
+        .decodeMessages(decoder = decoderAdapter.jsonDecoder)
+}

--- a/es-core/src/main/kotlin/io/provenance/eventstream/stream/flows/MetadataFlow.kt
+++ b/es-core/src/main/kotlin/io/provenance/eventstream/stream/flows/MetadataFlow.kt
@@ -1,0 +1,110 @@
+package io.provenance.eventstream.stream.flows
+
+import io.provenance.eventstream.decoder.DecoderAdapter
+import io.provenance.eventstream.net.NetAdapter
+import io.provenance.eventstream.stream.models.BlockHeader
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.buffer
+import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.dropWhile
+import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.selects.select
+import mu.KotlinLogging
+import java.util.concurrent.atomic.AtomicLong
+
+/**
+ * Create a [Flow] of [BlockHeader] from height to height.
+ *
+ * This flow will intelligently determine how to merge the live and history flows to
+ * create a seamless stream of [BlockHeader] objects.
+ *
+ * @param netAdapter The [NetAdapter] to use for network interfacing.
+ * @param decoderAdapter The [DecoderAdapter] to use to marshal json.
+ * @param from The `from` height, if omitted, height 1 is used.
+ * @param to The `to` height, if omitted, no end is assumed.
+ * @return The [Flow] of [BlockHeader].
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+fun metadataFlow(netAdapter: NetAdapter, decoderAdapter: DecoderAdapter, from: Long? = null, to: Long? = null): Flow<BlockHeader> = channelFlow {
+    val parent = this
+    val log = KotlinLogging.logger {}
+    val channel = Channel<BlockHeader>(capacity = 10_000) // buffer for: 10_000 * 6s block time / 60s/m / 60m/h == 16 2/3 hrs buffer time.
+    val liveJob = launch {
+        liveMetadataFlow(netAdapter, decoderAdapter)
+            .buffer()
+            .collect { channel.send(it) }
+    }
+    val current = netAdapter.rpcAdapter.getCurrentHeight()!!
+    log.debug { "hist//live split point:$current" }
+
+    // Determine if we need live data.
+    // ie: if to is null, or more than current,
+    val needLive = to == null || to > current
+
+    // Determine if we need historical data.
+    // ie: if from is null, or less than current, then we do.
+    val needHist = from == null || from < current
+    log.debug { "from:$from to:$to current:$current needHist:$needHist needLive:$needLive" }
+
+    // Cancel live job and channel if unneeded.
+    if (!needLive) {
+        liveJob.cancel()
+        channel.close()
+    }
+
+    // Process historical stream if needed.
+    val lastSeen = AtomicLong(0)
+    if (needHist) {
+        historicalMetadataFlow(netAdapter, from ?: 1, current)
+            .collect {
+                send(it)
+                lastSeen.set(it.height)
+            }
+    }
+
+    // Live flow. Skip any dupe blocks.
+    if (needLive) {
+        var firstLive = channel.receive()
+        var lastCurrent = current
+
+        // Determine if we have a gap between the last seen current and first received that needs to be filled.
+        // If fetching and emitting the gap takes longer that the time to fetch a new block, loop and do it again
+        // until the next block to be emitted is the head of the channel.
+        do {
+            log.debug { "gap fill from ${lastCurrent + 1} to ${firstLive.height}" }
+            historicalMetadataFlow(netAdapter, lastCurrent + 1, firstLive.height)
+                .collect { block ->
+                    // Update the lastSeen height after successful send.
+                    select {
+                        onSend(block) {
+                            lastSeen.set(block.height)
+                        }
+                    }
+                }
+            lastCurrent = firstLive.height
+            firstLive = channel.receive()
+        } while (lastCurrent + 1 < firstLive.height)
+
+        // Send the last known head of the channel.
+        send(firstLive)
+        lastSeen.set(firstLive.height)
+
+        // Continue receiving everything else live.
+        // Drop anything between current head and the last fetched history record.
+        channel.receiveAsFlow().dropWhile {
+            it.height <= lastSeen.get()
+        }.collect { block ->
+            select {
+                onSend(block) {
+                    if (to != null && block.height >= to) {
+                        parent.close()
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
* Add declarative style `historicalBlockMetaData()` and merged `metadataFlow()` for the historical fetch, and the historical+live fetch.
* Add NetAdapter to allow non-okhttp client implementations.