### PR TITLE
Add tests for functional streams methods, fix reconnect issues

### DIFF
--- a/es-core/build.gradle.kts
+++ b/es-core/build.gradle.kts
@@ -20,6 +20,11 @@ dependencies {
     implementation(libs.json)
     implementation(libs.moshi.kotlin.codegen)
 
+    testFixturesImplementation("io.reactivex.rxjava2:rxjava:2.1.16")
+    testFixturesImplementation("org.reactivestreams:reactive-streams:1.0.3")
+    testFixturesImplementation("com.tinder.scarlet:scarlet-core-internal:0.1.12")
+    testFixturesImplementation(libs.bundles.logback)
+
     testFixturesImplementation(projects.esApiModel)
 }
 

--- a/es-core/src/main/kotlin/io/provenance/eventstream/Defaults.kt
+++ b/es-core/src/main/kotlin/io/provenance/eventstream/Defaults.kt
@@ -5,7 +5,6 @@ import com.tinder.scarlet.Scarlet
 import com.tinder.scarlet.WebSocket
 import com.tinder.scarlet.lifecycle.LifecycleRegistry
 import com.tinder.scarlet.retry.BackoffStrategy
-import com.tinder.scarlet.retry.ExponentialBackoffStrategy
 import com.tinder.scarlet.retry.ExponentialWithJitterBackoffStrategy
 import com.tinder.streamadapter.coroutines.CoroutinesStreamAdapterFactory
 import io.provenance.eventstream.stream.WebSocketChannel
@@ -13,7 +12,6 @@ import io.provenance.eventstream.stream.flows.DEFAULT_THROTTLE_PERIOD
 import kotlinx.coroutines.CancellationException
 import mu.KotlinLogging
 import java.lang.reflect.Type
-import kotlin.math.max
 import kotlin.time.Duration
 
 /**

--- a/es-core/src/main/kotlin/io/provenance/eventstream/adapter/json/decoder/MoshiDecoderEngine.kt
+++ b/es-core/src/main/kotlin/io/provenance/eventstream/adapter/json/decoder/MoshiDecoderEngine.kt
@@ -5,6 +5,7 @@ import com.squareup.moshi.JsonDataException
 import com.squareup.moshi.JsonEncodingException
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.Types
+import java.io.EOFException
 import java.lang.reflect.ParameterizedType
 import java.lang.reflect.Type
 import kotlin.reflect.KClass
@@ -21,6 +22,8 @@ class MoshiDecoderEngine(private val moshi: Moshi) : DecoderEngine {
                     throw DecoderDataException(e)
                 } catch (e: JsonEncodingException) {
                     throw DecoderEncodingException(e)
+                } catch (e: EOFException) {
+                    throw DecoderDataException(e)
                 }
         }
     }

--- a/es-core/src/main/kotlin/io/provenance/eventstream/net/NetAdapter.kt
+++ b/es-core/src/main/kotlin/io/provenance/eventstream/net/NetAdapter.kt
@@ -10,7 +10,7 @@ import io.provenance.eventstream.stream.clients.BlockFetcher
  * @param rpcAdapter The [BlockFetcher] used to make rpc calls to the node.
  * @return The [NetAdapter] instance.
  */
-fun netAdapter(wsAdapter: WsAdapter, rpcAdapter: BlockFetcher, shutdown: () -> Unit): NetAdapter {
+fun netAdapter(wsAdapter: WsAdapter, rpcAdapter: BlockFetcher, shutdown: () -> Unit = {}): NetAdapter {
     return object : NetAdapter {
         override val wsAdapter: WsAdapter = wsAdapter
         override val rpcAdapter: BlockFetcher = rpcAdapter

--- a/es-core/src/main/kotlin/io/provenance/eventstream/net/OkHttpAdapter.kt
+++ b/es-core/src/main/kotlin/io/provenance/eventstream/net/OkHttpAdapter.kt
@@ -7,21 +7,23 @@ import io.provenance.eventstream.stream.clients.TendermintServiceOpenApiClient
 import mu.KotlinLogging
 import okhttp3.OkHttpClient
 import java.net.URI
-import java.util.concurrent.TimeUnit
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
-import kotlin.time.ExperimentalTime
+import kotlin.time.toJavaDuration
 
 private val SSL_SCHEMES = setOf("grpcs", "https", "tcp+tls", "wss")
 private val NON_SSL_SCHEMES = setOf("grpc", "http", "tcp", "ws")
+
 /**
  * Create a default [OkHttpClient] to use within the event stream.
  */
-@OptIn(ExperimentalTime::class)
 fun defaultOkHttpClient(pingInterval: Duration = 10.seconds, readInterval: Duration = 60.seconds) =
     OkHttpClient.Builder()
-        .pingInterval(pingInterval.inWholeMilliseconds, TimeUnit.MILLISECONDS)
-        .readTimeout(readInterval.inWholeMilliseconds, TimeUnit.MILLISECONDS)
+        .pingInterval(pingInterval.toJavaDuration())
+        .readTimeout(readInterval.toJavaDuration())
+        .connectTimeout(90.seconds.toJavaDuration())
+        .callTimeout(30.seconds.toJavaDuration())
+        .retryOnConnectionFailure(false)
         .build()
 
 /**

--- a/es-core/src/main/kotlin/io/provenance/eventstream/stream/clients/BlockFetcher.kt
+++ b/es-core/src/main/kotlin/io/provenance/eventstream/stream/clients/BlockFetcher.kt
@@ -4,7 +4,6 @@ import io.provenance.eventstream.stream.models.Block
 import io.provenance.eventstream.stream.models.BlockMeta
 import io.provenance.eventstream.stream.models.BlockResultsResponse
 import io.provenance.eventstream.stream.models.BlockResultsResponseResult
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.DEFAULT_CONCURRENCY
 import kotlinx.coroutines.flow.Flow
@@ -17,7 +16,7 @@ data class BlockData(val block: Block, val blockResult: BlockResultsResponseResu
 
 open class BlockFetchException(m: String) : Exception(m)
 
-@OptIn(FlowPreview::class, ExperimentalCoroutinesApi::class)
+@OptIn(FlowPreview::class)
 interface BlockFetcher {
     suspend fun getBlocksMeta(min: Long, max: Long): List<BlockMeta>?
     suspend fun getCurrentHeight(): Long?

--- a/es-core/src/main/kotlin/io/provenance/eventstream/stream/flows/WsBlockDataFlow.kt
+++ b/es-core/src/main/kotlin/io/provenance/eventstream/stream/flows/WsBlockDataFlow.kt
@@ -16,10 +16,11 @@ import io.provenance.eventstream.stream.models.Block
 import io.provenance.eventstream.stream.models.BlockHeader
 import io.provenance.eventstream.stream.rpc.response.MessageType
 import io.provenance.eventstream.stream.withLifecycle
-import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.asFlow
+import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.transform
 import kotlin.time.Duration
 
 /**
@@ -58,6 +59,7 @@ fun wsBlockDataFlow(
 ): Flow<BlockData> {
     return nodeEventStream<MessageType.NewBlock>(netAdapter, decoderAdapter, throttle, lifecycle, backoffStrategy, channel, wss)
         .mapBlockData(netAdapter)
+        .contiguous(netAdapter.rpcAdapter::getBlock) { it.height }
 }
 
 /**
@@ -66,8 +68,30 @@ fun wsBlockDataFlow(
  * @param netAdapter The [NetAdapter] to use to interface with the node rpc.
  * @return The [Flow] of [BlockData]
  */
-@OptIn(FlowPreview::class, ExperimentalCoroutinesApi::class)
 fun Flow<MessageType.NewBlock>.mapBlockData(netAdapter: NetAdapter): Flow<BlockData> {
     val fetcher = netAdapter.rpcAdapter
     return map { fetcher.getBlock(it.block.data.value.block.header!!.height) }
+}
+
+/**
+ * Generate contiguous runs of data, aka: fill in the gaps.
+ *
+ * @param fallback Method to pull any missing T's by the id provided.
+ * @param indexer Method to pull id from the next T.
+ *
+ * ```kotlin
+ *     listOf(1, 5).asFlow().contiguous({ it }) { it }.toList() == listOf(1, 2, 3, 4, 5)
+ * ```
+ */
+internal fun <T> Flow<T>.contiguous(fallback: suspend (id: Long) -> T, indexer: (T) -> Long): Flow<T> {
+    var current: Long? = null
+    return transform { item ->
+        val index = indexer(item)
+        if (current != null && current!!.inc() < index) {
+            // Uh-oh! Found a gap. Fill it in. Don't use fallback for current item.
+            emitAll(((current!!.inc()) until index).asFlow().map(fallback))
+        }
+        current = index
+        emit(item)
+    }
 }

--- a/es-core/src/main/kotlin/io/provenance/eventstream/stream/flows/WsBlockHeaderFlow.kt
+++ b/es-core/src/main/kotlin/io/provenance/eventstream/stream/flows/WsBlockHeaderFlow.kt
@@ -45,4 +45,5 @@ fun wsBlockHeaderFlow(
 ): Flow<BlockHeader> {
     return nodeEventStream<MessageType.NewBlockHeader>(netAdapter, decoderAdapter, throttle, lifecycle, backoffStrategy, channel, wss)
         .mapLiveBlockHeader()
+        .contiguous({ netAdapter.rpcAdapter.getBlocksMeta(it, it)!!.first().header!! }) { it.height }
 }

--- a/es-core/src/test/kotlin/io/provenance/eventstream/StreamTests.kt
+++ b/es-core/src/test/kotlin/io/provenance/eventstream/StreamTests.kt
@@ -155,6 +155,7 @@ class StreamTests : TestBase() {
 
         @OptIn(ExperimentalCoroutinesApi::class)
         @Test
+        // duped
         fun testBlockResponse() {
 
             val tendermint: TendermintServiceClient = ServiceMocker.Builder()
@@ -185,6 +186,7 @@ class StreamTests : TestBase() {
 
         @OptIn(ExperimentalCoroutinesApi::class)
         @Test
+        // duped
         fun testBlockResultsResponse() {
 
             val tendermint: TendermintServiceClient = ServiceMocker.Builder()
@@ -295,6 +297,7 @@ class StreamTests : TestBase() {
 
         @OptIn(ExperimentalCoroutinesApi::class, kotlinx.coroutines.FlowPreview::class)
         @Test
+        // done
         fun testHistoricalBlockStreaming() {
 
             dispatcherProvider.runBlockingTest {
@@ -325,6 +328,7 @@ class StreamTests : TestBase() {
 
         @OptIn(ExperimentalCoroutinesApi::class, kotlinx.coroutines.FlowPreview::class)
         @Test
+        // done
         fun testMetadataStreaming() {
 
             dispatcherProvider.runBlockingTest {
@@ -357,6 +361,7 @@ class StreamTests : TestBase() {
 
         @OptIn(ExperimentalCoroutinesApi::class)
         @Test
+        //
         fun testLiveBlockStreaming() {
 
             dispatcherProvider.runBlockingTest {
@@ -389,6 +394,7 @@ class StreamTests : TestBase() {
 
         @OptIn(ExperimentalCoroutinesApi::class, kotlinx.coroutines.FlowPreview::class)
         @Test
+        //
         fun testCombinedBlockStreaming() {
 
             dispatcherProvider.runBlockingTest {

--- a/es-core/src/test/kotlin/io/provenance/eventstream/stream/clients/TendermintBlockFetcherTest.kt
+++ b/es-core/src/test/kotlin/io/provenance/eventstream/stream/clients/TendermintBlockFetcherTest.kt
@@ -1,0 +1,95 @@
+package io.provenance.eventstream.stream.clients
+
+import io.provenance.eventstream.mocks.mockBlockFetcher
+import io.provenance.eventstream.test.base.TestBase
+import io.provenance.eventstream.test.utils.MIN_HISTORICAL_BLOCK_HEIGHT
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.assertThrows
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@OptIn(ExperimentalCoroutinesApi::class)
+class TendermintBlockFetcherTest : TestBase() {
+    private val tendermint = mockBlockFetcher(templates)
+
+    @BeforeAll
+    override fun setup() {
+        super.setup()
+    }
+
+    @AfterAll
+    override fun tearDown() {
+        super.tearDown()
+    }
+
+    @Test
+    fun testBlockResponse() {
+        val height = MIN_HISTORICAL_BLOCK_HEIGHT
+
+        scopedTest {
+            assert(tendermint.getBlock(height).block.header?.height == height)
+        }
+
+        assertThrows<Throwable> {
+            scopedTest {
+                tendermint.getBlock(-1)
+            }
+        }
+
+        assertThrows<Throwable> {
+            scopedTest {
+                tendermint.getBlock(999999999)
+            }
+        }
+    }
+
+    @Test
+    fun testBlockResultsResponse() {
+        val expectedHeight = MIN_HISTORICAL_BLOCK_HEIGHT
+
+        // Expect success:
+        dispatcherProvider.runBlockingTest {
+            assert(tendermint.getBlockResults(expectedHeight)?.result?.height == expectedHeight)
+        }
+
+        // Retrieving a non-existent block should fail (negative case):
+        assertThrows<Throwable> {
+            dispatcherProvider.runBlockingTest {
+                tendermint.getBlockResults(-1)
+            }
+        }
+
+        // Retrieving a non-existent block should fail (non-existent case):
+        assertThrows<Throwable> {
+            dispatcherProvider.runBlockingTest {
+                tendermint.getBlockResults(999999999)
+            }
+        }
+    }
+
+    @Test
+    fun testBlockchainResponse() {
+        val expectedMinHeight: Long = MIN_HISTORICAL_BLOCK_HEIGHT
+        val expectedMaxHeight: Long = expectedMinHeight + 20 - 1
+
+        scopedTest {
+            val blockMetas = tendermint.getBlocksMeta(expectedMinHeight, expectedMaxHeight)
+
+            assert(blockMetas?.size == 20)
+
+            val expectedHeights: Set<Long> = (expectedMinHeight..expectedMaxHeight).toSet()
+            val heights: Set<Long> = blockMetas?.mapNotNull { b -> b.header?.height }?.toSet() ?: setOf()
+
+            assert((expectedHeights - heights).isEmpty())
+        }
+
+        assertThrows<Throwable> {
+            dispatcherProvider.runBlockingTest {
+                tendermint.getBlocksMeta(-expectedMinHeight, expectedMaxHeight)
+            }
+        }
+    }
+}

--- a/es-core/src/test/kotlin/io/provenance/eventstream/stream/flows/BlockDataFlowTest.kt
+++ b/es-core/src/test/kotlin/io/provenance/eventstream/stream/flows/BlockDataFlowTest.kt
@@ -1,0 +1,216 @@
+package io.provenance.eventstream.stream.flows
+
+import io.provenance.eventstream.decoder.moshiDecoderAdapter
+import io.provenance.eventstream.mocks.mockEventStreamService
+import io.provenance.eventstream.mocks.mockNetAdapter
+import io.provenance.eventstream.stream.WebSocketService
+import io.provenance.eventstream.stream.clients.BlockData
+import io.provenance.eventstream.stream.models.BlockHeader
+import io.provenance.eventstream.test.base.TestBase
+import io.provenance.eventstream.test.utils.EXPECTED_LIVE_TOTAL_BLOCK_COUNT
+import io.provenance.eventstream.test.utils.EXPECTED_NONEMPTY_BLOCKS
+import io.provenance.eventstream.test.utils.EXPECTED_TOTAL_BLOCKS
+import io.provenance.eventstream.test.utils.MAX_HISTORICAL_BLOCK_HEIGHT
+import io.provenance.eventstream.test.utils.MAX_LIVE_BLOCK_HEIGHT
+import io.provenance.eventstream.test.utils.MIN_HISTORICAL_BLOCK_HEIGHT
+import io.provenance.eventstream.test.utils.MIN_LIVE_BLOCK_HEIGHT
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.toList
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.assertThrows
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@OptIn(ExperimentalCoroutinesApi::class)
+class BlockDataFlowTest : TestBase() {
+    private val netAdapter = mockNetAdapter(templates)
+
+    @BeforeAll
+    override fun setup() {
+        super.setup()
+    }
+
+    @AfterAll
+    override fun tearDown() {
+        super.tearDown()
+    }
+
+    fun mockBlockDataFlow(wss: WebSocketService): Flow<BlockData> {
+        val wsFlow = wsBlockDataFlow(netAdapter, moshiDecoderAdapter(), wss = wss)
+        val hFlow = historicalBlockDataFlow(netAdapter, MIN_HISTORICAL_BLOCK_HEIGHT, MAX_HISTORICAL_BLOCK_HEIGHT)
+        return blockDataFlow(
+            netAdapter,
+            MIN_HISTORICAL_BLOCK_HEIGHT,
+            MAX_LIVE_BLOCK_HEIGHT,
+            { _, _ -> hFlow },
+            { wsFlow }
+        )
+    }
+
+    fun mockBlockHeaderFlow(wss: WebSocketService): Flow<BlockHeader> {
+        val wsFlow = wsBlockHeaderFlow(netAdapter, moshiDecoderAdapter(), wss = wss)
+        val hFlow = historicalBlockHeaderFlow(netAdapter, MIN_HISTORICAL_BLOCK_HEIGHT, MAX_HISTORICAL_BLOCK_HEIGHT)
+        return blockHeaderFlow(
+            netAdapter,
+            MIN_HISTORICAL_BLOCK_HEIGHT,
+            MAX_LIVE_BLOCK_HEIGHT,
+            { _, _ -> hFlow },
+            { wsFlow }
+        )
+    }
+
+    @Nested
+    inner class Historical {
+        @Test
+        fun testBlockFlow() {
+            scopedTest {
+                val fetched = historicalBlockDataFlow(
+                    netAdapter = netAdapter,
+                    from = MIN_HISTORICAL_BLOCK_HEIGHT,
+                    to = MAX_HISTORICAL_BLOCK_HEIGHT,
+                ).toList()
+
+                assert(fetched.size.toLong() == EXPECTED_TOTAL_BLOCKS)
+            }
+
+            scopedTest {
+                val fetched = historicalBlockHeaderFlow(
+                    netAdapter = netAdapter,
+                    from = MIN_HISTORICAL_BLOCK_HEIGHT,
+                    to = MAX_HISTORICAL_BLOCK_HEIGHT,
+                ).toList()
+
+                assert(fetched.size.toLong() == EXPECTED_TOTAL_BLOCKS)
+            }
+        }
+
+        @Test
+        fun testBlockFiltering() {
+            scopedTest {
+                // If skipping empty blocks, we should get EXPECTED_NONEMPTY_BLOCKS:
+                val collectedSkip = historicalBlockDataFlow(
+                    netAdapter,
+                    MIN_HISTORICAL_BLOCK_HEIGHT,
+                    MAX_HISTORICAL_BLOCK_HEIGHT
+                ).filter { (it.block.data?.txs.orEmpty()).isNotEmpty() }.toList()
+
+                assert(collectedSkip.size.toLong() == EXPECTED_NONEMPTY_BLOCKS)
+            }
+
+            scopedTest {
+                // If skipping empty blocks, we should get EXPECTED_NONEMPTY_BLOCKS:
+                val collectedSkip = historicalBlockHeaderFlow(
+                    netAdapter,
+                    MIN_HISTORICAL_BLOCK_HEIGHT,
+                    MAX_HISTORICAL_BLOCK_HEIGHT
+                ).filter { it.height == MIN_HISTORICAL_BLOCK_HEIGHT }.toList()
+
+                assert(collectedSkip.size == 1)
+            }
+        }
+
+        @Test
+        fun testBlockMeta() {
+            scopedTest {
+                // If not skipping empty blocks, we should get EXPECTED_TOTAL_BLOCKS:
+                val collectedNoSkip = historicalBlockMetaFlow(
+                    netAdapter,
+                    MIN_HISTORICAL_BLOCK_HEIGHT,
+                    MAX_HISTORICAL_BLOCK_HEIGHT
+                ).toList()
+
+                assert(collectedNoSkip.size.toLong() == EXPECTED_TOTAL_BLOCKS)
+
+                // If skipping empty blocks, we should get EXPECTED_NONEMPTY_BLOCKS:
+                val collectedSkip = historicalBlockMetaFlow(
+                    netAdapter,
+                    MIN_HISTORICAL_BLOCK_HEIGHT,
+                    MAX_HISTORICAL_BLOCK_HEIGHT
+                ).filter { (it.numTxs ?: 0) > 0 }.toList()
+
+                assert(collectedSkip.size.toLong() == EXPECTED_NONEMPTY_BLOCKS)
+                assert(collectedSkip.size.toLong() == EXPECTED_NONEMPTY_BLOCKS)
+            }
+        }
+    }
+
+    @Nested
+    inner class WebSocket {
+        @Test
+        fun testBlockStreaming() {
+            scopedTest {
+                val service = mockEventStreamService(templates, dispatcherProvider)
+                val collected = wsBlockDataFlow(netAdapter, moshiDecoderAdapter(), wss = service).toList()
+                assert(collected.size.toLong() == EXPECTED_LIVE_TOTAL_BLOCK_COUNT) {
+                    "collected:${collected.size} expected:$EXPECTED_LIVE_TOTAL_BLOCK_COUNT"
+                }
+            }
+        }
+
+        @Test
+        fun testBlockStreamingMissedBlocksCatchUp() {
+            scopedTest {
+                // Range of ranges, first block, last block, nothing more.
+                val ranges = listOf(
+                    MIN_LIVE_BLOCK_HEIGHT..MIN_LIVE_BLOCK_HEIGHT,
+                    MAX_LIVE_BLOCK_HEIGHT..MAX_LIVE_BLOCK_HEIGHT,
+                )
+
+                val service = mockEventStreamService(templates, dispatcherProvider, ranges)
+                val collected = wsBlockDataFlow(netAdapter, moshiDecoderAdapter(), wss = service).toList()
+                assert(collected.size.toLong() == EXPECTED_LIVE_TOTAL_BLOCK_COUNT) {
+                    "collected:${collected.size} expected:$EXPECTED_LIVE_TOTAL_BLOCK_COUNT"
+                }
+            }
+        }
+
+        @Test
+        fun testBlockStreamCancelOnPanic() {
+            assertThrows<CancellationException> {
+                scopedTest {
+                    val service = mockEventStreamService(templates, dispatcherProvider) {
+                        response(templates.read("rpc/responses/panic.json"))
+                    }
+
+                    wsBlockDataFlow(netAdapter, moshiDecoderAdapter(), wss = service).toList()
+                }
+            }
+        }
+    }
+
+    @Nested
+    inner class Combo {
+        @Test
+        fun testBlockStreamGoodBlocksThenPanic() = scopedTest {
+            val service = mockEventStreamService(templates, dispatcherProvider) {
+                response(templates.read("rpc/responses/panic.json"))
+            }
+
+            assertThrows<CancellationException> {
+                scopedTest {
+                    mockBlockDataFlow(service).collect()
+                }
+            }
+        }
+
+        @Test
+        fun testBlockStreamImmediatePanic() = scopedTest {
+            val service = mockEventStreamService(templates, dispatcherProvider, emptyList()) {
+                response(templates.read("rpc/responses/panic.json"))
+            }
+
+            assertThrows<CancellationException> {
+                scopedTest {
+                    mockBlockDataFlow(service).collect()
+                }
+            }
+        }
+    }
+}

--- a/es-core/src/testFixtures/kotlin/io/provenance/eventstream/base/TestBase.kt
+++ b/es-core/src/testFixtures/kotlin/io/provenance/eventstream/base/TestBase.kt
@@ -3,11 +3,15 @@ package io.provenance.eventstream.test.base
 import io.provenance.eventstream.test.utils.Defaults
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestCoroutineScope
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.setMain
 
 @OptIn(ExperimentalCoroutinesApi::class)
 open class TestBase {
+
+    fun scopedTest(block: suspend TestCoroutineScope.() -> Unit) =
+        dispatcherProvider.runBlockingTest(block)
 
     val decoderEngine = Defaults.decoderEngine()
     val templates = Defaults.templates

--- a/es-core/src/testFixtures/kotlin/io/provenance/eventstream/mocks/MockEventStreamService.kt
+++ b/es-core/src/testFixtures/kotlin/io/provenance/eventstream/mocks/MockEventStreamService.kt
@@ -8,7 +8,6 @@ import io.provenance.eventstream.coroutines.DispatcherProvider
 import io.provenance.eventstream.stream.WebSocketService
 import io.provenance.eventstream.stream.rpc.request.Subscribe
 import io.provenance.eventstream.test.utils.Defaults
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.ChannelIterator
 import kotlinx.coroutines.channels.ReceiveChannel
@@ -126,7 +125,6 @@ class MockEventStreamService private constructor(
         }
     }
 
-    @OptIn(ExperimentalCoroutinesApi::class)
     override fun subscribe(subscribe: Subscribe) {
         runBlocking(dispatchers.io()) {
             channel.send(WebSocket.Event.OnConnectionOpened(Unit))

--- a/es-core/src/testFixtures/kotlin/io/provenance/eventstream/mocks/MockNetAdapter.kt
+++ b/es-core/src/testFixtures/kotlin/io/provenance/eventstream/mocks/MockNetAdapter.kt
@@ -1,0 +1,108 @@
+package io.provenance.eventstream.mocks
+
+import com.tinder.scarlet.Message
+import com.tinder.scarlet.ShutdownReason
+import com.tinder.scarlet.Stream
+import com.tinder.scarlet.WebSocket
+import com.tinder.scarlet.utils.toStream
+import io.provenance.eventstream.WsAdapter
+import io.provenance.eventstream.coroutines.DispatcherProvider
+import io.provenance.eventstream.net.NetAdapter
+import io.provenance.eventstream.net.netAdapter
+import io.provenance.eventstream.stream.WebSocketService
+import io.provenance.eventstream.stream.clients.BlockData
+import io.provenance.eventstream.stream.clients.BlockFetcher
+import io.provenance.eventstream.stream.models.ABCIInfoResponse
+import io.provenance.eventstream.stream.models.BlockMeta
+import io.provenance.eventstream.stream.models.BlockResponse
+import io.provenance.eventstream.stream.models.BlockResultsResponse
+import io.provenance.eventstream.stream.models.BlockchainResponse
+import io.provenance.eventstream.test.mocks.MockEventStreamService
+import io.provenance.eventstream.test.utils.MAX_LIVE_BLOCK_HEIGHT
+import io.provenance.eventstream.test.utils.MIN_LIVE_BLOCK_HEIGHT
+import io.provenance.eventstream.test.utils.Template
+import io.reactivex.Flowable
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.asFlow
+import java.util.concurrent.atomic.AtomicBoolean
+import kotlin.coroutines.CoroutineContext
+
+suspend fun mockEventStreamService(
+    template: Template,
+    dispatcherProvider: DispatcherProvider,
+    ranges: List<LongRange> = listOf(MIN_LIVE_BLOCK_HEIGHT..MAX_LIVE_BLOCK_HEIGHT),
+    init: MockEventStreamService.Builder.() -> Unit = {},
+): WebSocketService = MockEventStreamService.Builder().apply {
+    ranges.forEach { range ->
+        range.forEach { height ->
+            response(template.read("live/$height.json"))
+        }
+    }
+}.dispatchers(dispatcherProvider).also(init).build()
+
+fun mockWsAdapter(template: Template): WsAdapter {
+    return object : WsAdapter {
+        val closed = AtomicBoolean(true)
+        val empty = listOf(WebSocket.Event.OnMessageReceived(Message.Text("")))
+
+        val responses = template.readAll("live").toList().map {
+            WebSocket.Event.OnMessageReceived(Message.Text(it))
+        }
+
+        val data get() = Flowable.fromIterable(empty + responses)
+
+        override fun invoke(): WebSocket {
+            return object : WebSocket {
+                override fun cancel() {
+                    closed.set(true)
+                }
+
+                override fun close(shutdownReason: ShutdownReason): Boolean {
+                    closed.set(true)
+                    return true
+                }
+
+                override fun open(): Stream<WebSocket.Event> {
+                    closed.set(false)
+                    return data.toStream() as Stream<WebSocket.Event>
+                }
+
+                override fun send(message: Message): Boolean {
+                    TODO("Not yet implemented")
+                }
+            }
+        }
+    }
+}
+
+fun mockBlockFetcher(template: Template): BlockFetcher {
+    return object : BlockFetcher {
+        override suspend fun getBlocksMeta(min: Long, max: Long): List<BlockMeta>? {
+            val response = template.readAs(BlockchainResponse::class.java, "blockchain/$min-$max.json")
+            return response?.result?.blockMetas
+        }
+
+        override suspend fun getCurrentHeight(): Long {
+            val response = template.readAs(ABCIInfoResponse::class.java, "abci_info/success.json")
+            return response!!.result!!.response.lastBlockHeight!!
+        }
+
+        override suspend fun getBlock(height: Long): BlockData {
+            val block = template.readAs(BlockResponse::class.java, "block/$height.json")
+            val results = template.readAs(BlockResultsResponse::class.java, "block_results/$height.json")
+            return BlockData(block!!.result!!.block!!, results!!.result)
+        }
+
+        override suspend fun getBlockResults(height: Long): BlockResultsResponse? {
+            return template.readAs(BlockResultsResponse::class.java, "block_results/$height.json")
+        }
+
+        override suspend fun getBlocks(heights: List<Long>, concurrency: Int, context: CoroutineContext): Flow<BlockData> {
+            return heights.map { getBlock(it) }.asFlow()
+        }
+    }
+}
+
+fun mockNetAdapter(template: Template): NetAdapter {
+    return netAdapter(mockWsAdapter(template), mockBlockFetcher(template))
+}

--- a/es-core/src/testFixtures/kotlin/io/provenance/eventstream/utils/Constants.kt
+++ b/es-core/src/testFixtures/kotlin/io/provenance/eventstream/utils/Constants.kt
@@ -1,7 +1,6 @@
 package io.provenance.eventstream.test.utils
 
 import io.provenance.eventstream.stream.EventStream
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 
 /***********************************************************************************************************************
  * Streaming
@@ -27,15 +26,18 @@ const val MIN_LIVE_BLOCK_HEIGHT: Long = 3126935
  */
 const val MAX_LIVE_BLOCK_HEIGHT: Long = 3126940
 
-const val EXPECTED_TOTAL_BLOCKS: Long = (MAX_HISTORICAL_BLOCK_HEIGHT - MIN_HISTORICAL_BLOCK_HEIGHT) + 1
+const val EXPECTED_LIVE_TOTAL_BLOCK_COUNT = (MAX_LIVE_BLOCK_HEIGHT - MIN_LIVE_BLOCK_HEIGHT) + 1
+
+const val EXPECTED_TOTAL_BLOCKS = (MAX_HISTORICAL_BLOCK_HEIGHT - MIN_HISTORICAL_BLOCK_HEIGHT) + 1
 
 const val EXPECTED_NONEMPTY_BLOCKS: Long = 29
 
-const val EXPECTED_EMPTY_BLOCKS: Long = EXPECTED_TOTAL_BLOCKS - EXPECTED_NONEMPTY_BLOCKS
+const val EXPECTED_EMPTY_BLOCKS = EXPECTED_TOTAL_BLOCKS - EXPECTED_NONEMPTY_BLOCKS
 
 val heights: List<Long> = (MIN_HISTORICAL_BLOCK_HEIGHT..MAX_HISTORICAL_BLOCK_HEIGHT).toList()
 
-@OptIn(ExperimentalCoroutinesApi::class)
+const val COMBO_TOTAL_NONEMPTY_BLOCK_COUNT = EXPECTED_LIVE_TOTAL_BLOCK_COUNT + EXPECTED_TOTAL_BLOCKS
+
 val heightChunks: List<Pair<Long, Long>> = heights
     .chunked(EventStream.TENDERMINT_MAX_QUERY_RANGE)
     .map { Pair(it.minOrNull()!!, it.maxOrNull()!!) }


### PR DESCRIPTION
* Fix websocket reconnect issues
* Use contiguous() method to fill in missing live blocks as they are received from the ws
* Add test cases for tendermint block fetcher and functional streams calls.