### PR TITLE
Allow for connection retry when connection timeout occurs

### DIFF
--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -4,7 +4,7 @@ object Versions {
         const val Lang3 = "3.12.0"
         const val Text = "1.9"
     }
-    const val Hoplite = "1.4.15"
+    const val Hoplite = "2.1.4"
     object JUnit {
         const val Core = "5.3.1"
         const val Pioneer = "1.4.2"

--- a/es-cli/src/main/kotlin/Main.kt
+++ b/es-cli/src/main/kotlin/Main.kt
@@ -3,10 +3,9 @@ package io.provenance.eventstream
 // linting is giving a hard time on these kotlinx packages that cannot be auto-corrected,
 // IntelliJ is also giving linting errors if the imports are changed to individual imports.
 // ktlint-disable no-wildcard-imports
-import com.sksamuel.hoplite.ConfigLoader
+import com.sksamuel.hoplite.ConfigLoaderBuilder
 import com.sksamuel.hoplite.PropertySource
-import com.sksamuel.hoplite.addCommandLineSource
-import com.sksamuel.hoplite.addEnvironmentSource
+import com.sksamuel.hoplite.sources.EnvironmentVariablesPropertySource
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import com.tinder.scarlet.Scarlet
 import com.tinder.scarlet.messageadapter.moshi.MoshiMessageAdapter
@@ -63,10 +62,10 @@ fun main(args: Array<String>) {
      *
      * @see https://github.com/sksamuel/hoplite#environmentvariablespropertysource
      */
-    val config: Config = ConfigLoader.Builder()
-        .addCommandLineSource(args)
-        .addEnvironmentSource(useUnderscoresAsSeparator = true, allowUppercaseNames = true)
-        .addPropertySource(PropertySource.resource("/application.yml"))
+
+    val config: Config = ConfigLoaderBuilder.default()
+        .addSource(EnvironmentVariablesPropertySource(useUnderscoresAsSeparator = true, allowUppercaseNames = true))
+        .addSource(PropertySource.resource("/application.yml"))
         .build()
         .loadConfigOrThrow()
 

--- a/es-core/src/main/kotlin/io/provenance/eventstream/net/OkHttpAdapter.kt
+++ b/es-core/src/main/kotlin/io/provenance/eventstream/net/OkHttpAdapter.kt
@@ -23,7 +23,6 @@ fun defaultOkHttpClient(pingInterval: Duration = 10.seconds, readInterval: Durat
         .readTimeout(readInterval.toJavaDuration())
         .connectTimeout(90.seconds.toJavaDuration())
         .callTimeout(30.seconds.toJavaDuration())
-        .retryOnConnectionFailure(false)
         .build()
 
 /**


### PR DESCRIPTION
By default connection retry is enabled if flag is not set.

- Other minor fixes due to hoplite version upgrade